### PR TITLE
fix: :bug: register entities directly.

### DIFF
--- a/custom_components/flukso/binary_sensor.py
+++ b/custom_components/flukso/binary_sensor.py
@@ -1,10 +1,5 @@
 """Flukso binary sensor."""
-import functools
-
-from homeassistant.components import binary_sensor
-from homeassistant.components.mqtt.binary_sensor import (DISCOVERY_SCHEMA,
-                                                         MqttBinarySensor)
-from homeassistant.components.mqtt.mixins import async_setup_entry_helper
+from homeassistant.components.mqtt.binary_sensor import MqttBinarySensor
 from homeassistant.const import Platform
 
 from .const import DOMAIN
@@ -12,19 +7,8 @@ from .discovery import get_entities_for_platform
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up MQTT binary sensor through configuration.yaml and dynamically through MQTT discovery."""
-    setup = functools.partial(
-        _async_setup_entity, hass, async_add_entities, config_entry=config_entry
-    )
-    await async_setup_entry_helper(hass, binary_sensor.DOMAIN, setup, DISCOVERY_SCHEMA)
-
-
-async def _async_setup_entity(hass, async_add_entities, config, config_entry=None, discovery_data=None):
     """Set up MQTT binary sensor."""
     configs = get_entities_for_platform(
-        Platform.BINARY_SENSOR,
-        hass.data[DOMAIN][config_entry.entry_id]
+        Platform.BINARY_SENSOR, hass.data[DOMAIN][config_entry.entry_id]
     )
-    async_add_entities(
-        [MqttBinarySensor(hass, c, config_entry, discovery_data) for c in configs]
-    )
+    async_add_entities([MqttBinarySensor(hass, c, config_entry, None) for c in configs])

--- a/custom_components/flukso/sensor.py
+++ b/custom_components/flukso/sensor.py
@@ -1,9 +1,5 @@
 """Flukso sensor."""
-import functools
-
-from homeassistant.components import sensor
-from homeassistant.components.mqtt.mixins import async_setup_entry_helper
-from homeassistant.components.mqtt.sensor import DISCOVERY_SCHEMA, MqttSensor
+from homeassistant.components.mqtt.sensor import MqttSensor
 from homeassistant.const import Platform
 
 from .const import DOMAIN
@@ -11,19 +7,8 @@ from .discovery import get_entities_for_platform
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up MQTT sensor through configuration.yaml and dynamically through MQTT discovery."""
-    setup = functools.partial(
-        _async_setup_entity, hass, async_add_entities, config_entry=config_entry
-    )
-    await async_setup_entry_helper(hass, sensor.DOMAIN, setup, DISCOVERY_SCHEMA)
-
-
-async def _async_setup_entity(hass, async_add_entities, config, config_entry=None, discovery_data=None):
-    """Add a Flukso sensor."""
+    """Set up MQTT sensor."""
     configs = get_entities_for_platform(
-        Platform.SENSOR,
-        hass.data[DOMAIN][config_entry.entry_id]
+        Platform.SENSOR, hass.data[DOMAIN][config_entry.entry_id]
     )
-    async_add_entities(
-        [MqttSensor(hass, c, config_entry, discovery_data) for c in configs]
-    )
+    async_add_entities([MqttSensor(hass, c, config_entry, None) for c in configs])


### PR DESCRIPTION
Registering entities through async_setup_entry_helper is not correct, the partial setup function is called for each entity defined in the yaml file (zero or many times).
Revert to direct registration in async_setup_entry_helper as it was in 1.0.8.

Fixes #10, fixes #11

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@e-bulles.be>